### PR TITLE
Fix off-by-one error in the loadout validation. Patch by raven.

### DIFF
--- a/gamedata/scripts/magazine_binder.script
+++ b/gamedata/scripts/magazine_binder.script
@@ -208,16 +208,16 @@ function update_loadout_slots()
 end
 
 function validate_loadout()
-	update_loadout_slots()
-	local found = {small =0 ,medium = 0,large = 0}
-	for id, mag in pairs(carried_mags) do
-		if mag.size then
-			found[mag.size] = found[mag.size] + 1
-			if found[mag.size] >= loadout_slots[mag.size] then
-				carried_mags[id] = nil
-			end
-		end
-	end
+    update_loadout_slots()
+    local found = {small = 0, medium = 0, large = 0}
+    for id, mag in pairs(carried_mags) do
+        if mag.size then
+            found[mag.size] = found[mag.size] + 1
+            if found[mag.size] > loadout_slots[mag.size] then
+                carried_mags[id] = nil
+            end
+        end
+    end
 end
 
 function room_in_pouch(id)


### PR DESCRIPTION
Comparison should have been GT, not GTE. This caused the last magazine in loadout to be removed from loadout when actor picked up anything.