### PR TITLE
Add custom "condition" bars for magazines.

### DIFF
--- a/gamedata/scripts/ish_mag_bars.script
+++ b/gamedata/scripts/ish_mag_bars.script
@@ -1,0 +1,25 @@
+-- Customize to your liking.
+local mag_bars_custom = true
+local mag_bars_background = true
+local mag_bars_color = GetARGB(255, 200, 200, 200)
+-- Stop customizing.
+
+local Base_Add_ProgressBar = utils_ui.UICellItem.Add_ProgressBar
+local is_magazine = magazine_binder.is_magazine
+
+utils_ui.UICellItem.Add_ProgressBar = function(sender, xml, obj, sec, clsid)
+
+    Base_Add_ProgressBar(sender, xml, obj, sec, clsid)
+
+    if mag_bars_custom and sender.bar and is_magazine(sec) then
+        sender.bar:ShowBackground(mag_bars_background)
+        sender.bar:SetColor(mag_bars_color)
+    end
+
+end
+
+local vanilla_bar_list_for_reference_not_used_here = {
+    ["condition_progess_bar"] = {min = {255, 196, 18, 18, 0}, mid = {255, 255, 255, 118, 0.5}, max = {255, 107, 207, 119, 1}, background = true},
+    ["power_progess_bar"] = {def = GetARGB(255, 86, 196, 209), background = true},
+    ["uses_progess_bar"] = {def = GetARGB(255, 255, 255, 255), background = false}
+}


### PR DESCRIPTION
The three built-in anomaly condition bars are not entirely suitable for magazines.

"condition_progess_bar" changes colors for lower conditions, making the magazines look "damaged" when empty.
"power_progess_bar" is reserved for devices that require battery juice (which is blue)
"uses_progess_bar" (white) does not have faded background dots, so it does not convey the idea of capacity.

This patch adds static white condition bars with faded background for all redux magazines.