### PR TITLE
Fix some jam/unjam issues in MagsRedux and Ammo Check

### DIFF
--- a/ammo check/gamedata/scripts/ammo_check_mcm.script
+++ b/ammo check/gamedata/scripts/ammo_check_mcm.script
@@ -116,7 +116,7 @@ function checkAmmo()
     local sec = weapon:section()
     local top_round = nil
 
-    if (is_jammed_weapon(weaponId)) then
+    if (is_jammed_weapon(weapon)) then
         message = game.translate_string("st_ac_jammed")
         clr = use_clr and clr00_Red or nil
     elseif currentAmmo == 0 then

--- a/ammo check/gamedata/scripts/ammo_check_mcm.script
+++ b/ammo check/gamedata/scripts/ammo_check_mcm.script
@@ -4,8 +4,6 @@ hide_counter = true
 hide_ammo_icon = true
 
 -- locals --
-local jammed_weapon = false
-
 local clr00_Red = GetARGB(0xff, 0xff, 0x00, 0x00)
 local clr01_RedOrange = GetARGB(0xff, 0xff, 0x40, 0x00)
 local clr02_Orange = GetARGB(0xff, 0xff, 0x80, 0x00)
@@ -35,6 +33,7 @@ print_dbg = magazine_binder.print_dbg
 get_data = magazine_binder.get_data
 set_data = magazine_binder.set_data
 is_supported_weapon = magazine_binder.is_supported_weapon
+is_jammed_weapon = magazines.is_jammed_weapon
 
 function l_round(value)
     local min = math.floor(value + 0.5)
@@ -43,8 +42,6 @@ end
 
 function on_game_start()
     RegisterScriptCallback("on_key_press", on_key_press)
-    RegisterScriptCallback("actor_on_weapon_jammed", weapon_jammed)
-    RegisterScriptCallback("actor_on_weapon_reload", on_reload)
     RegisterScriptCallback("actor_on_first_update", actor_on_first_update)
     RegisterScriptCallback("on_option_change", on_option_change)
 end
@@ -91,14 +88,6 @@ function on_key_press(key)
     end
 end
 
-function weapon_jammed()
-    jammed_weapon = true
-end
-
-function on_reload()
-    jammed_weapon = false
-end
-
 -- Main function --
 function checkAmmo()
     local weapon = db.actor:active_item()
@@ -126,7 +115,8 @@ function checkAmmo()
 
     local sec = weapon:section()
     local top_round = nil
-    if (jammed_weapon) then
+
+    if (is_jammed_weapon(weaponId)) then
         message = game.translate_string("st_ac_jammed")
         clr = use_clr and clr00_Red or nil
     elseif currentAmmo == 0 then

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -600,6 +600,10 @@ function weapon_jammed(weapon)
 	jammed_guns[weapon:id()] = true
 end
 
+function is_jammed_weapon(weapon_id)
+	return jammed_guns[weapon_id] or false
+end
+
 -- Load next round into the weapon. 
 -- feed_next removes top round and feeds one after. otherwise feeds current
 function prep_weapon(weapon, feed_next)

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -301,8 +301,8 @@ function actor_on_weapon_reload(actor, weapon, ammo_total)
 	-- cancel reload only if we have a valid mag
 	if not weapon or not is_supported_weapon(weapon) or is_grenade_mode() then return end
 
-	if jammed_guns[weapon:id()] then
-		jammed_guns[weapon:id()] = nil
+	if is_jammed_weapon(weapon) then
+		weapon_unjammed(weapon)
 		local hud_section = SYS_GetParam(0, weapon:section(), "hud")
 		if SYS_GetParam(0, hud_section, "anm_reload_misfire") == nil then
 			-- actually do the weapon replace logic here
@@ -352,7 +352,7 @@ function unjam_weapon(weapon)
 	-- local fire_queue = 0 -- this shit complicated do later
 	local old_weapon = alife_object(weapon:id())
 	local new_weapon = alife_clone_weapon(old_weapon)
-	jammed_guns[id] = nil
+	weapon_unjammed(weapon)
 	print_dbg("New weapon should have %s ammo", #data.loaded)
 	on_key_press()
 	CreateTimeEvent("Mag_redux", "unjam_weapon", 0.5, unjam_weapon_timer, new_weapon.id, data, slot)
@@ -588,6 +588,8 @@ end
 -----------------------------------------
 
 function actor_on_weapon_fired(obj, weapon, ammo_elapsed, grenade_elapsed, ammo_type, grenade_type)
+	weapon_unjammed(weapon) --this is only needed here for automatic shotguns, because they do not trigger the reload callback.
+
 	if is_grenade_mode() then  
 		return
 	end
@@ -595,13 +597,21 @@ function actor_on_weapon_fired(obj, weapon, ammo_elapsed, grenade_elapsed, ammo_
 	prep_weapon(weapon, true)
 end
 
+function weapon_unjammed(weapon)
+    local weapon_id = weapon:id()
+    if jammed_guns[weapon_id] then
+        print_dbg("Removing jammed weapon entry %s", weapon_id)
+        jammed_guns[weapon_id] = nil
+    end
+end
+
 function weapon_jammed(weapon)
 	print_dbg("Logging jammed weapon %s", weapon:id())
 	jammed_guns[weapon:id()] = true
 end
 
-function is_jammed_weapon(weapon_id)
-	return jammed_guns[weapon_id] or false
+function is_jammed_weapon(weapon)
+	return jammed_guns[weapon:id()] or false
 end
 
 -- Load next round into the weapon. 


### PR DESCRIPTION
A best-effort attempt to fix #31.

Ammo Check no longer relies on a singleton flag to detect weapon jam. All jam detection is delegated to Redux.
It is not possible to detect reload event for auto shotties, so we remove them from jam table when fired.

Also some cleanup and refactoring involving jammed_guns functions.