### PR TITLE
Add standalone mode to Ammo Check addon

### DIFF
--- a/ammo check/gamedata/scripts/ammo_check_mcm.script
+++ b/ammo check/gamedata/scripts/ammo_check_mcm.script
@@ -27,13 +27,32 @@ local messages = {
     {m = "st_ac_full", c = clr06_White} -- full
 }
 
+function ac_print_dbg(msg, ...)
+    printf("![AC] " .. msg, ...)
+end
+
+function null_function()
+    return false
+end
+
 -- aliases--
 gc = game.translate_string
-print_dbg = magazine_binder.print_dbg
-get_data = magazine_binder.get_data
-set_data = magazine_binder.set_data
-is_supported_weapon = magazine_binder.is_supported_weapon
-is_jammed_weapon = magazines.is_jammed_weapon
+
+if magazine_binder then
+    print_dbg = magazine_binder.print_dbg
+    get_data = magazine_binder.get_data
+    set_data = magazine_binder.set_data
+    is_supported_weapon = magazine_binder.is_supported_weapon
+    is_jammed_weapon = magazines.is_jammed_weapon
+    print_dbg("MagsRedux installed. Working in integrated mode.")
+else
+    print_dbg = ac_print_dbg -- Use own print function.
+    get_data = null_function -- Should not be called, just in case.
+    set_data = null_function -- Should not be called, just in case.
+    is_supported_weapon = null_function -- Always returns false, meaning none of the weapons are supported, fall back on vanilla ammo handling.
+    is_jammed_weapon = null_function -- Sadly, standalone mode does not report weapon jams for now.
+    print_dbg("MagsRedux not found. Working in standalone mode.")
+end
 
 function l_round(value)
     local min = math.floor(value + 0.5)
@@ -84,7 +103,11 @@ end
 function on_key_press(key)
     local bind = dik_to_bind(key)
     if (bind == key_bindings.kCUSTOM25) then
-        checkAmmo()
+        local success, err = pcall(checkAmmo)
+
+        if not success then
+            print_dbg("Error: %s", err)
+        end
     end
 end
 


### PR DESCRIPTION
Check for existence of MagsRedux and use dynamic aliasing to be able to work standalone.

Jammed weapon support is dropped in standalone mode, but it was not perfect anyway. We can always duplicate the jammed weapon tracking logic here if necessary.

Fixes #33.