### PR TITLE
An attempt at fixing the various mag_data corruptions

### DIFF
--- a/gamedata/scripts/magazine_binder.script
+++ b/gamedata/scripts/magazine_binder.script
@@ -29,7 +29,7 @@ function print_dbg( text , ...)
 	return nil
 end
 
-
+PAST_LOAD_DATA = false
 
 local look_up_table 	= ini_file_ex("magazines\\lookups.ltx")
 local weapons_lookup 	= ini_file_ex("magazines\\weapons\\importer.ltx")
@@ -45,7 +45,12 @@ function get_carried_mags(tbl)
 end
 
 function get_data(id)
-	return mags_storage[id] or nil
+	tbl = {}
+	if mags_storage[id] then
+		copy_table(tbl, mags_storage[id] )
+		return tbl
+	end
+	return mags_storage[id] --could be nil or false want to return either.
 end
 
 function set_data(id, data)
@@ -458,6 +463,7 @@ end
 local freeze = false
 -- update the weight and condition based on capacity
 function magazine_binder:update(delta)
+	if not PAST_LOAD_DATA then return end
 	object_binder.update(self, delta)
 	local obj = self.object
 	local id = obj:id()
@@ -555,6 +561,7 @@ end
 local function load_state(mdata) 
 	mags_storage = mdata.mags_storage or {}
 	carried_mags = mdata.carried_mags or {}
+	PAST_LOAD_DATA = true
 end
 
 local function se_item_on_unregister(se_obj, typ)
@@ -595,6 +602,7 @@ function on_game_start()
 	RegisterScriptCallback("actor_item_to_slot",actor_item_to_slot)
 	RegisterScriptCallback("actor_item_to_ruck",actor_item_to_slot)
 	RegisterScriptCallback("actor_item_to_belt",actor_item_to_slot)
+	RegisterScriptCallback("actor_on_item_drop",actor_item_to_slot)
 	RegisterScriptCallback("server_entity_on_unregister",se_item_on_unregister)
 	RegisterScriptCallback("actor_on_first_update", actor_on_first_update)
 	RegisterScriptCallback("ActorMenu_on_trade_started",on_trade_opened)

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -252,7 +252,7 @@ function eject_magazine(weapon)
 		if #copy.loaded > 0 and weapon_in_slot(weapon) then
 			toggle_carried_mag(se_mag.id)
 		end
-		set_mag_data(id, nil)
+		set_mag_data(id, false)
 		dump_data(copy)
 	end
 end

--- a/gamedata/scripts/wep_binder.script
+++ b/gamedata/scripts/wep_binder.script
@@ -16,7 +16,8 @@ function wep_binder:__init(obj) super(obj)
    self.first_update = true
 end
 
-function wep_binder:update(delta) 
+function wep_binder:update(delta)
+	if not magazine_binder.PAST_LOAD_DATA then return end
 	local obj = self.object
 	if  not is_supported_weapon(obj) then
 		-- print_dbg("Spawned weapon does not use mags")
@@ -26,7 +27,7 @@ function wep_binder:update(delta)
 	
 	local id = obj:id()
 	local mag_data = get_data(id)
-	if mag_data and self.first_update then
+	if mag_data  and self.first_update then
 		self.first_update = false
 		local ammo_cap = SYS_GetParam(2, mag_data.section, "max_mag_size")
 		if ammo_cap and mag_data.loaded and #mag_data.loaded > ammo_cap then
@@ -36,10 +37,10 @@ function wep_binder:update(delta)
 			end
 		end
 	end
-	if not mag_data and self.first_update then
+	if  mag_data == nil and self.first_update then
 		self.first_update = false
 		local ammo_loaded = obj:get_ammo_in_magazine()
-		if ammo_loaded == 0 then return end
+		--if ammo_loaded == 0 then return end -- might not need this now.
 		local default_mag = weapon_default_magazine(obj:section())
 		mag_data = {}
 		mag_data.section = default_mag


### PR DESCRIPTION
Gun with ejected mag now has mag_storage entry set to false and wep_binder checks for nil explicitly before creating new entry.

both mag_binder and wep_binder are prevented from running until after load_state has run.

get_data returns a copy of the mag_storage entry  to prevent access by reference problems. this may make new problems.. idk needs testing

May need more play testing.