### PR TITLE
Revert "Simplify workflow."

### DIFF
--- a/ammo check/gamedata/scripts/ammo_check_mcm.script
+++ b/ammo check/gamedata/scripts/ammo_check_mcm.script
@@ -61,9 +61,8 @@ function on_game_start()
     end
 
     RegisterScriptCallback("on_key_press", on_key_press)
+    RegisterScriptCallback("actor_on_first_update", actor_on_first_update)
     RegisterScriptCallback("on_option_change", on_option_change)
-
-    on_option_change()
 end
 
 -- Script Callbacks --
@@ -82,6 +81,10 @@ function on_mcm_load()
     }
     -- LuaFormatter on
     return ch_options
+end
+
+function actor_on_first_update()
+    on_option_change()
 end
 
 function on_option_change()


### PR DESCRIPTION
This reverts commit a8df7bd04fca81019c8cad85533215afe4a6a14a.

This isn't just simplifying startup, it is actually affecting script loading order.
Also, on_option_change is attempting to access HUD, which may not be available at on_game_start.