### PR TITLE
Update magazine_binder.script

### DIFF
--- a/gamedata/scripts/magazine_binder.script
+++ b/gamedata/scripts/magazine_binder.script
@@ -165,7 +165,7 @@ local function type_correction(val)
         if obj  then
 			section = obj:section()
 		elseif se_obj then
-			section = se_obj:section()
+			section = se_obj:section_name()
 		else
 			print_dbg("WTF is:%s any way?", id)
 		end
@@ -173,7 +173,7 @@ local function type_correction(val)
         id = val.id
         se_obj = val
         obj = level.object_by_id(id)
-        section = val:section()
+        section = val:section_name()
     elseif type(val.id) == "function" then
         id = val:id()
         obj = val


### PR DESCRIPTION
somehow in all this time we have never passed an se_obj into any of the type correcting functions or this would have crashed.