### PR TITLE
Adding the other upgrade path into the SVT.

### DIFF
--- a/gamedata/configs/magazines/weapons/w_svt40.ltx
+++ b/gamedata/configs/magazines/weapons/w_svt40.ltx
@@ -12,4 +12,6 @@
 default_mag = mag_svt_7.62x54_default
 ;base_type
 ammo_7.62x54_7h1 = svt_7.62x54
+ammo_7.62x39_fmj = svt_7.62x39
 [wpn_svt40_modern]:wpn_svt40
+ 


### PR DESCRIPTION
support for one of the two SVT rechamber upgrades is handled by the odd svt basetype and a compatibility check when feeding a round.
the other requires a new base type that existed but was not listed on the weapon. 
I added that.