### PR TITLE
Adds a mcm slider controling what is considered an "empty" magazine

### DIFF
--- a/gamedata/configs/text/eng/st_items_magazines.xml
+++ b/gamedata/configs/text/eng/st_items_magazines.xml
@@ -160,10 +160,16 @@
 		<text>Put in loadout</text>
 	</string>
 
+	<string id="ui_mcm_magazines_mag_unequip_trs">
+		<text>Deactivation treshold %</text>
+	</string>
+	<string id="ui_mcm_magazines_mag_unequip_trs_desc">
+		<text>Enabled when "Put in backpack" or "Throw on ground" is selected \nMagazines that are full below this % will be deactivated.</text>
+	</string>
 	<!--MAGAZINES-->
 
 	<string id="st_dot">
-		<text>•</text>
+		<text>ï¿½</text>
 	</string>
 	<string id="st_mag_bonus">
 		<text>(Outfit:%s + Extra:%s)<!--alt:> (%s + %s)<--></text>

--- a/gamedata/configs/text/eng/st_items_magazines.xml
+++ b/gamedata/configs/text/eng/st_items_magazines.xml
@@ -169,7 +169,7 @@
 	<!--MAGAZINES-->
 
 	<string id="st_dot">
-		<text>ï¿½</text>
+		<text>•</text>
 	</string>
 	<string id="st_mag_bonus">
 		<text>(Outfit:%s + Extra:%s)<!--alt:> (%s + %s)<--></text>

--- a/gamedata/configs/text/eng/st_items_magazines.xml
+++ b/gamedata/configs/text/eng/st_items_magazines.xml
@@ -161,10 +161,10 @@
 	</string>
 
 	<string id="ui_mcm_magazines_mag_unequip_trs">
-		<text>Deactivation treshold %</text>
+		<text>Treat as empty %</text>
 	</string>
 	<string id="ui_mcm_magazines_mag_unequip_trs_desc">
-		<text>Enabled when "Put in backpack" or "Throw on ground" is selected \nMagazines that are full below this % will be deactivated.</text>
+		<text>Used for "Put in backpack" or "Throw on ground" option \nMagazines below this % will be treated as empty.</text>
 	</string>
 	<!--MAGAZINES-->
 

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -382,7 +382,9 @@ function timer_eject_magazine(weapon, id, mag_data)
 	local ejection_type = tonumber(get_config("ejection"))
 	print_dbg("ejection type is %s", ejection_type)
 	if weapon_in_slot(weapon) then
-		if #mag_data.loaded > 0 or ejection_type == 0 then
+		local capacity = SYS_GetParam(2, mag_data.section, "max_mag_size") or 20
+		local ammo_percent=#mag_data.loaded/capacity
+		if ammo_percent > (get_config('mag_unequip_trs')/100) or ejection_type == 0 then
 			toggle_carried_mag(id)
 		end
 	end

--- a/gamedata/scripts/magazines_mcm.script
+++ b/gamedata/scripts/magazines_mcm.script
@@ -12,7 +12,8 @@ local defaults = {
     retain_round    		= false,
     ejection        		= 0,
     mag_loadtime_factor		= 1,
-    mag_unloadtime_factor	= 1
+    mag_unloadtime_factor	= 1,
+    mag_unequip_trs         = 1
 }
 
 local colors = {--alpha value will be reset to match slider
@@ -46,6 +47,7 @@ function on_mcm_load()
             {id = "fast_loading", type = "check", val = 1, def=false},	
             {id = "retain_round", type = "check", val = 1, def=false},	
             {id = "ejection" ,type= "list" ,val= 0  ,def= "orange" ,content= {{0,"loadout"},{1,"ruck"}}},		
+            {id = "mag_unequip_trs", type = "track", val = 2, min=0,max=100,step=1, def = 1},
             {id = "debug", type = "check", val = 1, def=false},
         }
     }


### PR DESCRIPTION
Adds a slider in mcm to what is basically "deactivation threshold"
If a magazine is below user specified % value, it will be treated as empty


Because I'm annoyed by more than occasional loading mags with 1 round inside