### PR TITLE
Added an alternative fast loading mode

### DIFF
--- a/gamedata/configs/text/eng/st_items_magazines.xml
+++ b/gamedata/configs/text/eng/st_items_magazines.xml
@@ -136,11 +136,19 @@
 	<string id="ui_mcm_magazines_retain_round_desc">
 		<text>If enabled, weapons retain a round in the chamber when magazines are ejected.</text>
 	</string>
-	<string id="ui_mcm_magazines_fast_loading">
-		<text>Enable Fast Loading in Stashes</text>
-	</string>
 	<string id="ui_mcm_magazines_fast_loading_desc">
-		<text>If enabled, loading and unloading rounds in stashes will be instant, like in Escape from Tarkov.</text>
+		<text>If enabled, loading and unloading rounds in stashes will be instant, like in Escape from Tarkov.\n
+		Standard Mode : Both mags and ammo need to be in the stash inventory\n
+		Alt Mode: Mags and ammo need to be in the same inventory but can be in player's inventory</text>
+	</string>
+	<string id="ui_mcm_lst_magazines_fast_loading_off">
+		<text>Off</text>
+	</string>
+	<string id="ui_mcm_lst_magazines_fast_loading_standard">
+		<text>Standard</text>
+	</string>
+	<string id="ui_mcm_lst_magazines_fast_loading_alt">
+		<text>Alt</text>
 	</string>
 	<string id="ui_mcm_magazines_ejection">
 		<text>Empty mag unload behavior</text>

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -50,6 +50,10 @@ function parent_is_box(obj)
 	return false
 end
 
+function stash_is_open()
+	return ui_inventory.GUI and ui_inventory.GUI.mode == "loot" and ui_inventory.GUI.npc_is_box
+end
+
 function action_in_progress()
 	return ACTION_IN_PROGRESS
 end
@@ -152,8 +156,8 @@ function on_item_drag_dropped(item, weapon, from_slot, to_slot)
 	if(item_id == weapon_id) then
 		return
 	end
-	
-	local is_box_mode = (parent_is_box(item) and from_slot == EDDListType.iDeadBodyBag) and true or false
+
+	local is_fast_load = get_config("fast_loading") == 1 and (parent_is_box(item) and from_slot == EDDListType.iDeadBodyBag) or get_config("fast_loading") == 2 and stash_is_open() or false
 
 	-- bullet to mag
 	if(IsAmmo(item) and is_magazine(weapon)) then
@@ -166,7 +170,7 @@ function on_item_drag_dropped(item, weapon, from_slot, to_slot)
 		    local capacity = SYS_GetParam(2, weapon_sec, "max_mag_size")  or 20
 			print_dbg("start loading loop")
 			interrupt_loading = false
-			if get_config("fast_loading") and is_box_mode then
+			if is_fast_load and is_box_mode then
 				fast_load_magazine(weapon, item)
 			else
 				local delay = get_mag_time(weapon_sec, false)
@@ -627,7 +631,13 @@ function fast_load_magazine(magazine, box)
 			count_so_far = count_so_far + item:ammo_get_count()
 		end
 	end
-	parent:iterate_inventory_box(itr_box)
+
+	if parent:is_inventory_box() then
+		parent:iterate_inventory_box(itr_box)
+	else
+		parent:iterate_inventory(itr_box)
+	end
+
 	for k,v in pairs(boxes_to_load) do
 		local ammo_box = level.object_by_id(k)
 		local loaded = ammo_box:ammo_get_count() > ammo_to_load and ammo_to_load or ammo_box:ammo_get_count()
@@ -713,8 +723,8 @@ function func_unload_ammo(obj)
 		local mag_data = get_mag_data(id)
 		if mag_data and #mag_data.loaded > 0 then
 			interrupt_loading = false
-			if parent_is_box(obj)  then--get_config("fast_loading") and parent_is_box(obj) then
-				fast_unload_magazine(obj)
+			if get_config("fast_loading") == 1 and parent_is_box(obj) or get_config("fast_loading") == 2 and stash_is_open() or false then
+				fast_unload_magazine(obj)fast_unload_magazine(obj)
 			else
 				local delay = get_mag_time(obj:section(), true)	
 				print_dbg("Start unload magazine at speed %s", delay)

--- a/gamedata/scripts/magazines_mcm.script
+++ b/gamedata/scripts/magazines_mcm.script
@@ -44,7 +44,7 @@ function on_mcm_load()
             {id = "show_hud", type = "check", val = 1, def=true},			
             {id = "icon_text", type = "check", val = 1, def=true},			
             {id = "ammo_icon", type = "check", val = 1, def=true},			
-            {id = "fast_loading", type = "check", val = 1, def=false},	
+            {id= "fast_loading", type="radio_h", content ={ {0,"magazines_fast_loading_off"}, {1,"magazines_fast_loading_standard"}, {2,"magazines_fast_loading_alt"}}, val=2, def=0 },
             {id = "retain_round", type = "check", val = 1, def=false},	
             {id = "ejection" ,type= "list" ,val= 2  ,def= 1 ,content= {{0,"loadout"},{1,"ruck"}}},		
             {id = "mag_unequip_trs", type = "track", val = 2, min=0,max=100,step=1, def = 1},


### PR DESCRIPTION
Changed the fast loading mcm option to have two modes : 
* Standard act like previously
* Alt let's you fast load in the player inventory (as long as stash ui is opened)