### PR TITLE
Added alternative ways to load/unload ammo

### DIFF
--- a/gamedata/configs/text/eng/st_items_magazines.xml
+++ b/gamedata/configs/text/eng/st_items_magazines.xml
@@ -142,6 +142,20 @@
 	<string id="ui_mcm_magazines_fast_loading_desc">
 		<text>If enabled, loading and unloading rounds in stashes will be instant, like in Escape from Tarkov.</text>
 	</string>
+	<string id="ui_mcm_magazines_unload_key_modifier">
+		<text>Unload on hover keybind</text>
+	</string>
+
+	<string id="ui_mcm_magazines_unload_key_modifier_desc">
+		<text>When this keybind is pressed hovering over magazines will unload them</text>
+	</string>
+	<string id="ui_mcm_magazines_old_key_modifier">
+		<text>Old ammo select keybind</text>
+	</string>
+
+	<string id="ui_mcm_magazines_old_key_modifier_desc">
+		<text>When this keybind is pressed, right clicking on mags, will only show old ammo</text>
+	</string>
 	<string id="ui_mcm_magazines_ejection">
 		<text>Empty mag unload behavior</text>
 	</string>

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -36,6 +36,11 @@ block_reload_spam = false
 
 -- due to changing how mag loading works (1 big event vs. several events) we need this here to persist which box we are taking ammo from
 local ext_ammo_box = nil
+
+-- Unload on hover
+-- local unload_key_modifier = get_config("unload_key_mod")
+local unload_key_modifier = "kJUMP"
+local unload_flag = false
 ------------------------
 -- SECTION debug info --
 ------------------------
@@ -527,6 +532,27 @@ function find_next_box(ammo_section, id)
 	return item_to_get
 end
 
+-- local inv = ui_inventory.UIInventory.__init
+-- ui_inventory.UIInventory.__init = function(self)
+--     inv(self)
+--     self.properties["load_fmj"] = { index= #self.properties+1, name_func= "ammo_name", mode= {"inventory"}, cont= {"actor_bag"}, precondition1= {"available_ammo"}, action= {"mouse2_load"} },
+--     self.properties["load_ep"]  = { index= #self.properties+1, name_func= "ammo_name", mode= {"inventory"}, cont= {"actor_bag"}, precondition1= {"available_ammo"}, action= {"mouse2_load"} },
+--     self.properties["load_fmj"] = { index= #self.properties+1, name_func= "ammo_name", mode= {"inventory"}, cont= {"actor_bag"}, precondition1= {"available_ammo"}, action= {"mouse2_load"} }
+-- end
+--
+-- function ammo_name(obj)
+--     return get_item_name_debug(obj:section())
+-- end
+--
+-- function available_ammo(obj)
+--     for k,v in pairs(count_ammo()) do
+--         printf("key %s, value %s", k,v)
+--     end
+-- end
+--
+-- function mouse2_load(obj)
+--     printf("loading mag with %s",obj)
+-- end
 
 local last_time = 0
 -- position is ammo type as number
@@ -673,9 +699,37 @@ local direction_keys = {
 	[key_bindings.kL_STRAFE] = true,
 	[key_bindings.kR_STRAFE] = true
 }
+
+local cc = ui_inventory.UIInventory.On_CC_Hover
+ui_inventory.UIInventory.On_CC_Hover = function(self, cont, idx)
+    cc(self, cont, idx)
+
+    if unload_flag == true then
+        local mag = self.CC[cont]:GetObj(idx)
+        func_unload_ammo(mag)
+    end
+
+end
+
+function on_key_release(key)
+        local bind = dik_to_bind(key)
+
+        local bind = dik_to_bind(key)
+        if key_bindings[unload_key_modifier] == bind then
+            unload_flag = false
+        end
+end
+
 function on_key_press(key)
-	-- do not interrupt if directional key pressed
-	local bind = dik_to_bind(key)
+        if not key then return end
+
+        local bind = dik_to_bind(key)
+        -- flag for unload on hover
+        if key_bindings[unload_key_modifier] == bind then
+            unload_flag = true
+            return
+        end
+
 	if not interrupt_loading and not direction_keys[bind] then
 		print_dbg("Interrupting reload")
 		interrupt_loading = true
@@ -696,7 +750,6 @@ end
 -- 	block_reload_spam = false
 -- 	return true
 -- end
-
 function unload_ammo(obj)
 	if is_magazine(obj) then
 		local id = obj:id()
@@ -888,6 +941,7 @@ function on_game_start()
 	RegisterScriptCallback("ActorMenu_on_item_before_move", ActorMenu_on_item_before_move)
 	RegisterScriptCallback("ActorMenu_on_item_focus_receive", ActorMenu_on_item_focus_receive)
 	RegisterScriptCallback("on_key_press", on_key_press)
+	RegisterScriptCallback("on_key_release", on_key_release)
 	RegisterScriptCallback("actor_on_weapon_fired", actor_on_weapon_fired)
 	RegisterScriptCallback("actor_on_weapon_jammed", weapon_jammed)
 	RegisterScriptCallback("ActorMenu_on_item_drag_drop", on_item_drag_dropped)

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -41,6 +41,8 @@ local ext_ammo_box = nil
 -- local unload_key_modifier = get_config("unload_key_mod")
 local unload_key_modifier = "kJUMP"
 local unload_flag = false
+local old_key_modifier = "kWPN_RELOAD"
+local old_flag = false
 ------------------------
 -- SECTION debug info --
 ------------------------
@@ -158,6 +160,7 @@ function on_item_drag_dropped(item, weapon, from_slot, to_slot)
 		return
 	end
 	
+
 	local is_box_mode = (parent_is_box(item) and from_slot == EDDListType.iDeadBodyBag) and true or false
 
 	-- bullet to mag
@@ -532,27 +535,82 @@ function find_next_box(ammo_section, id)
 	return item_to_get
 end
 
--- local inv = ui_inventory.UIInventory.__init
--- ui_inventory.UIInventory.__init = function(self)
---     inv(self)
---     self.properties["load_fmj"] = { index= #self.properties+1, name_func= "ammo_name", mode= {"inventory"}, cont= {"actor_bag"}, precondition1= {"available_ammo"}, action= {"mouse2_load"} },
---     self.properties["load_ep"]  = { index= #self.properties+1, name_func= "ammo_name", mode= {"inventory"}, cont= {"actor_bag"}, precondition1= {"available_ammo"}, action= {"mouse2_load"} },
---     self.properties["load_fmj"] = { index= #self.properties+1, name_func= "ammo_name", mode= {"inventory"}, cont= {"actor_bag"}, precondition1= {"available_ammo"}, action= {"mouse2_load"} }
--- end
---
--- function ammo_name(obj)
---     return get_item_name_debug(obj:section())
--- end
---
--- function available_ammo(obj)
---     for k,v in pairs(count_ammo()) do
---         printf("key %s, value %s", k,v)
---     end
--- end
---
--- function mouse2_load(obj)
---     printf("loading mag with %s",obj)
--- end
+local inv = ui_inventory.UIInventory.__init
+ui_inventory.UIInventory.__init = function(self)
+	inv(self)
+	self.properties["load_fmj"] = { index= size_table(self.properties)+1, name_func= {"Name_Ammo", 1}, mode_func= {"Mode_Load"}, precondition1= {"Name_Ammo", 1}, action= {"Mouse_Load", 1} }
+	self.properties["load_ep"] = { index= size_table(self.properties)+1, name_func= {"Name_Ammo", 2}, mode_func= {"Mode_Load"}, precondition1= {"Name_Ammo", 2}, action= {"Mouse_Load", 2} }
+	self.properties["load_ap"] = { index= size_table(self.properties)+1, name_func= {"Name_Ammo", 3}, mode_func= {"Mode_Load"}, precondition1= {"Name_Ammo", 3}, action= {"Mouse_Load", 3} }
+	for _,props in pairs(self.properties) do
+		if props.mode then t2k_table(props.mode) end
+		if props.cont then t2k_table(props.cont) end
+	end
+end
+
+function mouse_get_ammo(mag,idx)
+	--[[
+		Ammo is returned is this order :
+		- first type
+		- first type bad
+		- first type verybad
+		- second type
+
+		So to get the type of ammo we want we take our index (fmj: 1, ep:2, ap:3)
+		and multiply it by three so we get 3,6 and 9.
+		Problem is theses idx correspond to verybad ammo, so we substract 1
+		to get bad ammo and two to get normal ammo
+		
+		Notes : Not all ammo have three type but afaik they are sorted
+		by pen/how good they are in ascending order. So first option will
+		always be the worst and the last the best.
+	]]--
+	local ammo_idx = old_flag == true and 1 or 2
+	return get_magazine_caliber(mag:section())[idx*3-ammo_idx]
+end
+
+ui_inventory.UIInventory.Name_Ammo = function(self, obj, bag, temp, i)
+
+	local mag  = self:CheckItem(obj,"Name_Ammo" .. i)
+	local ammo_sec = mouse_get_ammo(mag, i)
+	local inv = bag == "actor_bag" and db.actor or mag:parent()
+
+	-- Ammo section naming pattern is 'ammo_ammo-name_type_bad/verybad'
+	-- So here we get the type
+	local ammo_type = str_explode(ammo_sec,'_')[3]
+	
+	local old_str = old_flag == true and "old " or ""
+	
+	if not is_empty(utils_item.collect_amount(inv, ammo_sec, 0)) then
+		-- e.i "Load old FMJ ammo", "Load AP ammo"
+		return "Load " .. old_str .. ammo_type:upper() .. " ammo"
+	else
+		return false
+	end
+end
+
+ui_inventory.UIInventory.Mode_Load = function(self)
+	return  self.mode == "inventory" or self.mode == "loot" and true or false
+end
+
+ui_inventory.UIInventory.Mouse_Load = function(self, obj, bag, temp, i)
+
+	local mag = self:CheckItem(obj,"Mouse_Load" .. i)
+	local ammo_sec = mouse_get_ammo(mag, i)
+	local delay = get_mag_time(mag:section(), false)
+	local capacity = SYS_GetParam(2, mag:section(), "max_mag_size")  or 20
+
+	local ammo_obj = nil
+	local function itr(temp, obj)
+		if (obj:section() == ammo_sec) then ammo_obj = obj end
+	end
+	local inv = bag == "actor_bag" and db.actor or mag:parent()
+	inv:iterate_inventory(itr, nil)
+	ext_ammo_box = ammo_obj
+
+	interrupt_loading = false
+	RemoveTimeEvent("Mag_redux", "load_mag"..mag:id())
+	create_time_event("Mag_redux", "load_mag"..mag:id(), 0.1, load_magazine, mag, capacity, delay * 1000)
+end
 
 local last_time = 0
 -- position is ammo type as number
@@ -702,33 +760,42 @@ local direction_keys = {
 
 local cc = ui_inventory.UIInventory.On_CC_Hover
 ui_inventory.UIInventory.On_CC_Hover = function(self, cont, idx)
-    cc(self, cont, idx)
+	cc(self, cont, idx)
 
-    if unload_flag == true then
-        local mag = self.CC[cont]:GetObj(idx)
-        func_unload_ammo(mag)
-    end
+	if unload_flag == true then
+		local mag = self.CC[cont]:GetObj(idx)
+		func_unload_ammo(mag)
+	end
 
 end
 
 function on_key_release(key)
         local bind = dik_to_bind(key)
 
-        local bind = dik_to_bind(key)
         if key_bindings[unload_key_modifier] == bind then
             unload_flag = false
+        end
+        if key_bindings[old_key_modifier] == bind then
+            old_flag = false
         end
 end
 
 function on_key_press(key)
-        if not key then return end
+	if not key then return end
+	local bind = dik_to_bind(key)
 
-        local bind = dik_to_bind(key)
-        -- flag for unload on hover
-        if key_bindings[unload_key_modifier] == bind then
-            unload_flag = true
-            return
-        end
+	if ui_inventory.GUI and ui_inventory.GUI:IsShown() then
+		-- flag for unload on hover
+		if key_bindings[unload_key_modifier] == bind then
+			unload_flag = true
+			return
+		end
+		-- flag for old ammo_loading
+		if key_bindings[old_key_modifier] == bind then
+			old_flag = true
+			return
+		end
+	end
 
 	if not interrupt_loading and not direction_keys[bind] then
 		print_dbg("Interrupting reload")

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -43,6 +43,9 @@ local unload_key_modifier = "kJUMP"
 local unload_flag = false
 local old_key_modifier = "kWPN_RELOAD"
 local old_flag = false
+
+-- global table to keep track of selected ammos on right click
+local inv_ammo = {}
 ------------------------
 -- SECTION debug info --
 ------------------------
@@ -538,13 +541,30 @@ end
 local inv = ui_inventory.UIInventory.__init
 ui_inventory.UIInventory.__init = function(self)
 	inv(self)
-	self.properties["load_fmj"] = { index= size_table(self.properties)+1, name_func= {"Name_Ammo", 1}, mode_func= {"Mode_Load"}, precondition1= {"Name_Ammo", 1}, action= {"Mouse_Load", 1} }
-	self.properties["load_ep"] = { index= size_table(self.properties)+1, name_func= {"Name_Ammo", 2}, mode_func= {"Mode_Load"}, precondition1= {"Name_Ammo", 2}, action= {"Mouse_Load", 2} }
-	self.properties["load_ap"] = { index= size_table(self.properties)+1, name_func= {"Name_Ammo", 3}, mode_func= {"Mode_Load"}, precondition1= {"Name_Ammo", 3}, action= {"Mouse_Load", 3} }
-	for _,props in pairs(self.properties) do
-		if props.mode then t2k_table(props.mode) end
-		if props.cont then t2k_table(props.cont) end
-	end
+	self.properties["load_fmj"] = {
+		index= size_table(self.properties)+1,
+		name_func= {"Name_Ammo", 1},
+		mode= t2k_table({"inventory", "loot"}),
+		cont= t2k_table({"actor_equ","actor_bag","npc_bag"}),
+		precondition1= {"Name_Ammo", 1},
+		action= {"Mouse_Load", 1}
+	}
+	self.properties["load_ep"] = {
+		index= size_table(self.properties)+1,
+		name_func= {"Name_Ammo", 2},
+		mode= t2k_table({"inventory", "loot"}),
+		cont= t2k_table({"actor_equ","actor_bag","npc_bag"}),
+		precondition1= {"Name_Ammo", 2},
+		action= {"Mouse_Load", 2}
+	}
+	self.properties["load_ap"] = {
+		index= size_table(self.properties)+1,
+		name_func= {"Name_Ammo", 3},
+		mode= t2k_table({"inventory", "loot"}),
+		cont= t2k_table({"actor_equ","actor_bag","npc_bag"}),
+		precondition1= {"Name_Ammo", 3},
+		action= {"Mouse_Load", 3}
+	}
 end
 
 function mouse_get_ammo(mag,idx)
@@ -571,45 +591,81 @@ end
 ui_inventory.UIInventory.Name_Ammo = function(self, obj, bag, temp, i)
 
 	local mag  = self:CheckItem(obj,"Name_Ammo" .. i)
+	if not isMagazine(mag) then return end
+
+	-- If mag is already full, return
+	local capacity = SYS_GetParam(2, mag:section(), "max_mag_size")  or 20
+	if #get_mag_data(mag:id()).loaded >= capacity then return end
+
 	local ammo_sec = mouse_get_ammo(mag, i)
-	local inv = bag == "actor_bag" and db.actor or mag:parent()
-
-	-- Ammo section naming pattern is 'ammo_ammo-name_type_bad/verybad'
-	-- So here we get the type
-	local ammo_type = str_explode(ammo_sec,'_')[3]
-	
-	local old_str = old_flag == true and "old " or ""
-	
-	if not is_empty(utils_item.collect_amount(inv, ammo_sec, 0)) then
-		-- e.i "Load old FMJ ammo", "Load AP ammo"
-		return "Load " .. old_str .. ammo_type:upper() .. " ammo"
-	else
-		return false
+	if not ammo_sec then
+		print_dbg("No ammo could be found for %s", mag:section())
+		return
 	end
-end
 
-ui_inventory.UIInventory.Mode_Load = function(self)
-	return  self.mode == "inventory" or self.mode == "loot" and true or false
+	-- Check if ammo is present in inventory
+	local inv = mag:parent()
+	local inv_obj = false
+	if inv:is_inventory_box() then
+		function itr(temp, obj)
+			if obj:section() == ammo_sec then
+				inv_obj = true
+				return
+			end
+		end
+		inv:iterate_inventory_box(itr, nil)
+	else
+		inv_obj = not is_empty(utils_item.collect_amount(inv, ammo_sec, 0))
+	end
+	if inv_obj == true then
+		inv_ammo[i] = ammo_sec
+		-- Ammo section naming pattern is 'ammo_ammo-name_type_bad/verybad'
+		-- So here we get the type
+		local splitted_sec = str_explode(ammo_sec,'_')
+		local ammo_name = splitted_sec[2]
+		local ammo_type = splitted_sec[3]
+		local old_str = old_flag == true and "old " or ""
+		-- e.i "Load old FMJ ammo", "Load AP ammo"
+		return string.format("load %s%s %s", old_str, ammo_name, ammo_type:upper())
+	else
+		-- If no ammo is in inventory, retry with old ammo
+		if old_flag == true then return end
+
+		old_flag = true
+		local name_str = self.Name_Ammo(self, obj, bag, temp, i)
+		old_flag = false
+		if name_str then return name_str end
+	end
 end
 
 ui_inventory.UIInventory.Mouse_Load = function(self, obj, bag, temp, i)
 
 	local mag = self:CheckItem(obj,"Mouse_Load" .. i)
-	local ammo_sec = mouse_get_ammo(mag, i)
-	local delay = get_mag_time(mag:section(), false)
-	local capacity = SYS_GetParam(2, mag:section(), "max_mag_size")  or 20
+	local ammo_sec = inv_ammo[i]
+	inv_ammo = {}
+	if not ammo_sec then
+		print_dbg("Something weird happended... %s doesn't have ammo for it", mag:section())
+		return
+	end
 
+	-- Collect ammo object
 	local ammo_obj = nil
 	local function itr(temp, obj)
 		if (obj:section() == ammo_sec) then ammo_obj = obj end
 	end
-	local inv = bag == "actor_bag" and db.actor or mag:parent()
-	inv:iterate_inventory(itr, nil)
+	local inv = mag:parent()
+	if inv:is_inventory_box() then
+		inv:iterate_inventory_box(itr, nil)
+	else
+		inv:iterate_inventory(itr, nil)
+	end
 	ext_ammo_box = ammo_obj
 
+	local delay = get_mag_time(mag:section(), false)
+	local capacity = SYS_GetParam(2, mag:section(), "max_mag_size")  or 20
 	interrupt_loading = false
-	RemoveTimeEvent("Mag_redux", "load_mag"..mag:id())
-	create_time_event("Mag_redux", "load_mag"..mag:id(), 0.1, load_magazine, mag, capacity, delay * 1000)
+	RemoveTimeEvent("mag_redux", "load_mag"..mag:id())
+	create_time_event("mag_redux", "load_mag"..mag:id(), 0.1, load_magazine, mag, capacity, delay * 1000)
 end
 
 local last_time = 0
@@ -770,14 +826,17 @@ ui_inventory.UIInventory.On_CC_Hover = function(self, cont, idx)
 end
 
 function on_key_release(key)
-        local bind = dik_to_bind(key)
+	if not key then return end
+	local bind = dik_to_bind(key)
 
-        if key_bindings[unload_key_modifier] == bind then
-            unload_flag = false
-        end
-        if key_bindings[old_key_modifier] == bind then
-            old_flag = false
-        end
+	if key_bindings[unload_key_modifier] == bind then
+		unload_flag = false
+		return
+	end
+	if key_bindings[old_key_modifier] == bind then
+		old_flag = false
+		return
+	end
 end
 
 function on_key_press(key)

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -38,7 +38,6 @@ block_reload_spam = false
 local ext_ammo_box = nil
 
 -- Unload on hover
--- local unload_key_modifier = get_config("unload_key_mod")
 local unload_key_modifier = get_config("unload_key_modifier")
 local unload_flag = false
 local old_key_modifier = get_config("old_key_modifier")
@@ -609,14 +608,10 @@ ui_inventory.UIInventory.Name_Ammo = function(self, obj, bag, temp, i)
 	end
 	if inv_obj == true then
 		inv_ammo[i] = ammo_sec
-		-- Ammo section naming pattern is 'ammo_ammo-name_type_bad/verybad'
-		-- So here we get the type
-		local splitted_sec = str_explode(ammo_sec,'_')
-		local ammo_name = splitted_sec[2]
-		local ammo_type = splitted_sec[3]
-		local old_str = old_flag == true and "old " or ""
+
+		local old_str = old_flag == true and "(old)" or ""
 		-- e.i "Load old FMJ ammo", "Load AP ammo"
-		return string.format("load %s%s %s", old_str, ammo_name, ammo_type:upper())
+		return string.format("load %s %s", game.translate_string(ini_sys:r_string_ex(ammo_sec,"inv_name_short")), old_str)
 	else
 		-- If no ammo is in inventory, retry with old ammo
 		if old_flag == true then return end
@@ -821,12 +816,9 @@ local direction_keys = {
 	[key_bindings.kR_STRAFE] = true
 }
 
-local cc = ui_inventory.UIInventory.On_CC_Hover
-ui_inventory.UIInventory.On_CC_Hover = function(self, cont, idx)
-	cc(self, cont, idx)
-
+function on_hover(mag)
+	if not isMagazine(mag) then return end
 	if unload_flag == true then
-		local mag = self.CC[cont]:GetObj(idx)
 		func_unload_ammo(mag)
 	end
 
@@ -1084,5 +1076,6 @@ function on_game_start()
 	RegisterScriptCallback("ActorMenu_on_item_drag_drop", on_item_drag_dropped)
 	RegisterScriptCallback("server_entity_on_unregister",se_item_on_unregister)
 	RegisterScriptCallback("on_option_change",on_option_change)
+	RegisterScriptCallback("ActorMenu_on_item_focus_receive",on_hover)
 
 end 

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -1,4 +1,4 @@
-----------------------------------------------------------------
+
 -- Refactored magazines by Arti and Raven. Most of this code is cribbed from wuut_mags original, but cleaned up significantly.
 ----------------------------------------------------------------
 
@@ -39,9 +39,9 @@ local ext_ammo_box = nil
 
 -- Unload on hover
 -- local unload_key_modifier = get_config("unload_key_mod")
-local unload_key_modifier = "kJUMP"
+local unload_key_modifier = get_config("unload_key_modifier")
 local unload_flag = false
-local old_key_modifier = "kWPN_RELOAD"
+local old_key_modifier = get_config("old_key_modifier")
 local old_flag = false
 
 -- global table to keep track of selected ammos on right click
@@ -150,42 +150,23 @@ function on_item_drag_dropped(item, weapon, from_slot, to_slot)
 
 	print_dbg("on_item_drag_dropped " .. item:section() .. " on " .. weapon:section() .. " to_slot " .. to_slot)
 
-	-- Check capability
-	if not ((from_slot == EDDListType.iDeadBodyBag and to_slot == EDDListType.iDeadBodyBag) or (from_slot == EDDListType.iActorBag  and (to_slot == EDDListType.iActorBag or to_slot == EDDListType.iActorSlot))) then
+	-- Only allow drag and dropping in the same inventory e.i ammo and mag in stash/player inventory/dead npc
+	if not ((from_slot == EDDListType.iDeadBodyBag and to_slot == EDDListType.iDeadBodyBag) or
+		(from_slot == EDDListType.iActorBag  and (to_slot == EDDListType.iActorBag or
+		to_slot == EDDListType.iActorSlot))) then
         return
     end
-	local active_id = db.actor:active_item() and db.actor:active_item():id() or 0 
-	local item_id = item:id()
-	local item_sec = item:section()
+
 	local weapon_id = weapon:id()
-	local weapon_sec = weapon:section()
-	if(item_id == weapon_id) then
-		return
-	end
+	if item:id()  == weapon_id then return end
 	
-
-	local is_box_mode = (parent_is_box(item) and from_slot == EDDListType.iDeadBodyBag) and true or false
-
 	-- bullet to mag
 	if(IsAmmo(item) and is_magazine(weapon)) then
 		-- check compatibility, then fire (heh) the loading loop
 		local ammos = invert_table(get_magazine_caliber(weapon))
-		local ammo_sec = item_sec
 		print_dbg("Checking compat for ammo sec %s", ammo_sec)
-		if ammos[ammo_sec] ~= nil then
-			-- start loading loop
-		    local capacity = SYS_GetParam(2, weapon_sec, "max_mag_size")  or 20
-			print_dbg("start loading loop")
-			interrupt_loading = false
-			if get_config("fast_loading") and is_box_mode then
-				fast_load_magazine(weapon, item)
-			else
-				local delay = get_mag_time(weapon_sec, false)
-				print_dbg("Start load magazine at speed %s", delay)
-				ext_ammo_box = item
-				RemoveTimeEvent("Mag_redux", "load_mag"..weapon_id)
-				create_time_event("Mag_redux", "load_mag"..weapon_id, 0.1, load_magazine, weapon, capacity, delay * 1000)
-			end
+		if ammos[item:section()] ~= nil then
+			func_load_magazine(weapon, item)
 		end
 	end
 	-- mag to weapon
@@ -193,6 +174,7 @@ function on_item_drag_dropped(item, weapon, from_slot, to_slot)
 		if weapon:weapon_in_grenade_mode() then return end
 		-- init loading of weapon
 		print_dbg("Begin loading mag %s into weapon %s", item:section(), weapon:section())
+		local active_id = db.actor:active_item() and db.actor:active_item():id() or 0
 		if to_slot == EDDListType.iActorSlot and weapon_id == active_id then
 			local pre_table = count_ammo(weapon)
 			weapon:switch_state(7)
@@ -541,30 +523,38 @@ end
 local inv = ui_inventory.UIInventory.__init
 ui_inventory.UIInventory.__init = function(self)
 	inv(self)
+	local init_index = size_table(self.properties)+1
 	self.properties["load_fmj"] = {
-		index= size_table(self.properties)+1,
+		index= init_index,
 		name_func= {"Name_Ammo", 1},
-		mode= t2k_table({"inventory", "loot"}),
-		cont= t2k_table({"actor_equ","actor_bag","npc_bag"}),
+		mode= {"inventory", "loot"},
+		cont= {"actor_equ","actor_bag","npc_bag"},
 		precondition1= {"Name_Ammo", 1},
 		action= {"Mouse_Load", 1}
 	}
 	self.properties["load_ep"] = {
 		index= size_table(self.properties)+1,
 		name_func= {"Name_Ammo", 2},
-		mode= t2k_table({"inventory", "loot"}),
-		cont= t2k_table({"actor_equ","actor_bag","npc_bag"}),
+		mode= {"inventory", "loot"},
+		cont= {"actor_equ","actor_bag","npc_bag"},
 		precondition1= {"Name_Ammo", 2},
 		action= {"Mouse_Load", 2}
 	}
+	local final_index = size_table(self.properties)+1
 	self.properties["load_ap"] = {
-		index= size_table(self.properties)+1,
+		index= final_index,
 		name_func= {"Name_Ammo", 3},
-		mode= t2k_table({"inventory", "loot"}),
-		cont= t2k_table({"actor_equ","actor_bag","npc_bag"}),
+		mode= {"inventory", "loot"},
+		cont= {"actor_equ","actor_bag","npc_bag"},
 		precondition1= {"Name_Ammo", 3},
 		action= {"Mouse_Load", 3}
 	}
+	for _,prop in pairs(self.properties) do
+		if prop.index >= init_index and prop.index <= final_index then
+			if prop.mode then t2k_table(prop.mode) end
+			if prop.cont then t2k_table(prop.cont) end
+		end
+	end
 end
 
 function mouse_get_ammo(mag,idx)
@@ -643,15 +633,14 @@ ui_inventory.UIInventory.Mouse_Load = function(self, obj, bag, temp, i)
 	local mag = self:CheckItem(obj,"Mouse_Load" .. i)
 	local ammo_sec = inv_ammo[i]
 	inv_ammo = {}
-	if not ammo_sec then
-		print_dbg("Something weird happended... %s doesn't have ammo for it", mag:section())
-		return
-	end
 
 	-- Collect ammo object
 	local ammo_obj = nil
 	local function itr(temp, obj)
-		if (obj:section() == ammo_sec) then ammo_obj = obj end
+		if (obj:section() == ammo_sec) then
+			ammo_obj = obj
+			return
+		end
 	end
 	local inv = mag:parent()
 	if inv:is_inventory_box() then
@@ -659,13 +648,31 @@ ui_inventory.UIInventory.Mouse_Load = function(self, obj, bag, temp, i)
 	else
 		inv:iterate_inventory(itr, nil)
 	end
-	ext_ammo_box = ammo_obj
+	if not ammo_obj then
+		print_dbg("Something weird happended... %s doesn't have ammo for it", mag:section())
+		return
+	end
+	func_load_magazine(mag, ammo_obj)
+end
 
-	local delay = get_mag_time(mag:section(), false)
-	local capacity = SYS_GetParam(2, mag:section(), "max_mag_size")  or 20
+function func_load_magazine(mag, ammo)
+	print_dbg("start loading loop")
 	interrupt_loading = false
-	RemoveTimeEvent("mag_redux", "load_mag"..mag:id())
-	create_time_event("mag_redux", "load_mag"..mag:id(), 0.1, load_magazine, mag, capacity, delay * 1000)
+	local mag_sec = mag:section()
+	local mag_id = mag:id()
+	local capacity = SYS_GetParam(2, mag_sec, "max_mag_size")  or 20
+	ext_ammo_box = ammo
+
+	local is_box_mode = parent_is_box(ammo)
+	if get_config("fast_loading") and is_box_mode then
+		fast_load_magazine(mag)
+	else
+		local delay = get_mag_time(mag_sec, false)
+		local mag_id = mag_id
+		print_dbg("Start load magazine at speed %s", delay)
+		RemoveTimeEvent("Mag_redux", "load_mag"..mag_id)
+		create_time_event("Mag_redux", "load_mag"..mag_id, 0.1, load_magazine, mag, capacity, delay * 1000)
+	end
 end
 
 local last_time = 0
@@ -752,12 +759,12 @@ function unload_magazine(magazine, delay)
 	end
 end
 
-function fast_load_magazine(magazine, box)
+function fast_load_magazine(magazine)
 	local mag_data = get_mag_data(magazine:id())
 	print_dbg("begin fastload")
 	dump_data(mag_data)
-	local ammo_sec = box:section()
-	local parent = box:parent()
+	local ammo_sec = ext_ammo_box:section()
+	local parent = magazine:parent()
 	local ammo_to_load = SYS_GetParam(2, magazine:section(), "max_mag_size") - #mag_data.loaded
 	local boxes_to_load = {}
 	local count_so_far = 0
@@ -827,13 +834,12 @@ end
 
 function on_key_release(key)
 	if not key then return end
-	local bind = dik_to_bind(key)
 
-	if key_bindings[unload_key_modifier] == bind then
+	if unload_key_modifier == key then
 		unload_flag = false
 		return
 	end
-	if key_bindings[old_key_modifier] == bind then
+	if old_key_modifier == key then
 		old_flag = false
 		return
 	end
@@ -841,21 +847,21 @@ end
 
 function on_key_press(key)
 	if not key then return end
-	local bind = dik_to_bind(key)
 
 	if ui_inventory.GUI and ui_inventory.GUI:IsShown() then
 		-- flag for unload on hover
-		if key_bindings[unload_key_modifier] == bind then
+		if unload_key_modifier == key then
 			unload_flag = true
 			return
 		end
 		-- flag for old ammo_loading
-		if key_bindings[old_key_modifier] == bind then
+		if old_key_modifier == key then
 			old_flag = true
 			return
 		end
 	end
 
+	local bind = dik_to_bind(key)
 	if not interrupt_loading and not direction_keys[bind] then
 		print_dbg("Interrupting reload")
 		interrupt_loading = true
@@ -1063,6 +1069,11 @@ local function se_item_on_unregister(se_obj, typ)
 	ammo_maps[id] = nil
 end
 
+function on_option_change()
+	unload_key_modifier = get_config("unload_key_modifier")
+	old_key_modifier = get_config("old_key_modifier")
+end
+
 function on_game_start()
 	RegisterScriptCallback("ActorMenu_on_item_before_move", ActorMenu_on_item_before_move)
 	RegisterScriptCallback("ActorMenu_on_item_focus_receive", ActorMenu_on_item_focus_receive)
@@ -1072,5 +1083,6 @@ function on_game_start()
 	RegisterScriptCallback("actor_on_weapon_jammed", weapon_jammed)
 	RegisterScriptCallback("ActorMenu_on_item_drag_drop", on_item_drag_dropped)
 	RegisterScriptCallback("server_entity_on_unregister",se_item_on_unregister)
+	RegisterScriptCallback("on_option_change",on_option_change)
 
 end 

--- a/gamedata/scripts/magazines_mcm.script
+++ b/gamedata/scripts/magazines_mcm.script
@@ -13,7 +13,9 @@ local defaults = {
     ejection        		= 0,
     mag_loadtime_factor		= 1,
     mag_unloadtime_factor	= 1,
-    mag_unequip_trs         = 1
+    mag_unequip_trs         = 1,
+    unload_key_modifier = DIK_keys.DIK_CAPITAL,
+    old_key_modifier = DIK_keys.DIK_R
 }
 
 local colors = {--alpha value will be reset to match slider
@@ -48,7 +50,9 @@ function on_mcm_load()
             {id = "retain_round", type = "check", val = 1, def=false},	
             {id = "ejection" ,type= "list" ,val= 2  ,def= 1 ,content= {{0,"loadout"},{1,"ruck"}}},		
             {id = "mag_unequip_trs", type = "track", val = 2, min=0,max=100,step=1, def = 1},
-            {id = "debug", type = "check", val = 1, def=false},
+	    { id = "unload_key_modifier"             , type = "key_bind"          , val = 2, def = DIK_keys.DIK_CAPITAL },
+	    { id = "old_key_modifier"             , type = "key_bind"          , val = 2, def = DIK_keys.DIK_R },
+	    {id = "debug", type = "check", val = 1, def=false},
         }
     }
     return op


### PR DESCRIPTION
When hovering on a mag with a modifier key pressed (mcm configurable) mags are unloaded
Right clicking on a non-full mag will bring up the contextual menu where items for every ammo you have in your inventory are. Click one of them to reload your mag with said ammo
If you wanna bring up only old ammo on right click press a modifier key (mcm configurable)