### PR TITLE
Fix for the coonan 357

### DIFF
--- a/ppp_patch/gamedata/configs/magazines/basetypes/base_ppp.ltx
+++ b/ppp_patch/gamedata/configs/magazines/basetypes/base_ppp.ltx
@@ -1,6 +1,6 @@
 ;PrettyPepegas Pack
 
-[ppp_357_1911]
+[st_wpn_coonan357]
 caliber   = ammo_357_hp_mag, ammo_357_hp_mag_bad, ammo_357_hp_mag_verybad
 
 [ppp_45_svi]


### PR DESCRIPTION
Every pistol in the ppp patch needs to have its basetype name changed, as demonstrated with the coonan 357 patch i made