### PR TITLE
Ignore motion mark events from NPCs

### DIFF
--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -989,8 +989,8 @@ end
 
 -- Reload mid animation with motion marks
 -- Like vanilla, ignore name and force mag load on first motion mark
-function actor_on_hud_animation_mark(state, mark)
-	if action_in_progress() and state == 7 then
+function actor_on_hud_animation_mark(state, mark, hud_item, owner)
+	if action_in_progress() and state == 7 and (owner and owner:id() == AC_ID or false) then
         force_reload = true
 	end
 end


### PR DESCRIPTION
Previously, NPCs triggering the motion mark would prematurely complete the player's reload. This should ignore NPCs, using functionality from modded exes version 2023.12.06.

As a side effect, this change means that users with older versions of the modded exes won't have working motion marks (as `owner` is always `nil`) but we can reasonably expect people to update to latest anyways.