### PR TITLE
mcm hud slider for horizontal position and unload all mags with END key

### DIFF
--- a/gamedata/scripts/mag_hud.script
+++ b/gamedata/scripts/mag_hud.script
@@ -17,6 +17,7 @@ local gc						 	= game.translate_string
 local tg_update_step = 1000 --[ms]
 
 local scale = 1
+local hud_offset_x = 0
 local ammo_scale = 1
 local group_by_ammo = true
 local grp_by_bt = true
@@ -123,6 +124,9 @@ function UIMagHUD:InitControls()
 	
 	self.dialog = xml:InitStatic("pouch", self)
 	adjust_vert(self.dialog, self.bottom)
+	local pos = self.dialog:GetWndPos()
+    pos.x = hud_offset_x
+    self.dialog:SetWndPos(pos)
 	self.pouch = {}
 	self.pouch.small = xml:InitStatic("pouch:small", self.dialog)
 	adjust_vert(self.pouch.small)
@@ -361,6 +365,7 @@ end
 local function on_option_change(mcm)
 	--if not mcm then return end
 	scale = magazines_mcm.get_config("scale")
+	hud_offset_x = magazines_mcm.get_config("hud_offset_x") or 0
 	ammo_scale = magazines_mcm.get_config("ammo_scale")
 	group_by_ammo = magazines_mcm.get_config("group_by_ammo")
 	grp_by_bt = magazines_mcm.get_config("grp_by_bt")
@@ -373,6 +378,7 @@ end
 
 local function actor_on_first_update()
 	scale = magazines_mcm.get_config("scale")
+	hud_offset_x = magazines_mcm.get_config("hud_offset_x") or 0
 	ammo_scale = magazines_mcm.get_config("ammo_scale")
 	group_by_ammo = magazines_mcm.get_config("scale")
 	grp_by_bt = magazines_mcm.get_config("ammo_scale")

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -1089,7 +1089,7 @@ function unload_next_magazine()
     -- check if an action is in progress
     if action_state ~= ACTION_NONE then
         -- wait and retry every half sec
-        create_time_event("mag_redux", "unload_next_magazine", 0.5, unload_next_magazine)
+        create_time_event("mag_redux", "unload_next_magazine", 0.4, unload_next_magazine)
         return
     end
 
@@ -1098,7 +1098,7 @@ function unload_next_magazine()
     if obj then
         func_unload_ammo(obj)
         -- wait half sec for next mag
-        create_time_event("mag_redux", "unload_next_magazine", 0.5, unload_next_magazine)
+        create_time_event("mag_redux", "unload_next_magazine", 0.4, unload_next_magazine)
     end
 end
 

--- a/gamedata/scripts/magazines_mcm.script
+++ b/gamedata/scripts/magazines_mcm.script
@@ -11,6 +11,7 @@ local defaults = {
     icon_text				= true,
     ammo_icon				= true,
     scale					= 1,
+	hud_offset_x			= 0,
     ammo_scale				= 1,
     group_by_ammo			= true,
     grp_by_bt				= true,
@@ -28,6 +29,7 @@ local defaults = {
 	three_hands				= false,
     deathquality			= 1.0,
     deathammo				= 1.0,
+
 }
 
 local def_map = {
@@ -42,6 +44,7 @@ local def_map = {
     icon_text				= "hud",
     ammo_icon				= "hud",
     scale					= "hud",
+	hud_offset_x			= "hud",
     ammo_scale				= "hud",
     group_by_ammo			= "hud",
     grp_by_bt				= "hud",
@@ -58,6 +61,7 @@ local def_map = {
 	three_hands				= "gameplay",
     deathquality			= "gameplay",
     deathammo				= "gameplay",
+
 }
 
 local colors = {--alpha value will be reset to match slider
@@ -79,8 +83,8 @@ function on_mcm_load()
         {id = "mgmt",sh=true,gr={
             {id= "mgmtitle",type= "slide",text="ui_mcm_magazines_mgmtitle",link= "ui_options_slider_player",size= {512,50},spacing= 20},
             {id = "debug", type = "check", val = 1, def=false},
-            {id = "mag_loadtime_factor", type = "track", val = 2, min=0.4,max=2,step=0.1, def = 1},
-            {id = "mag_unloadtime_factor", type = "track", val = 2, min=0.4,max=2,step=0.1, def = 1},
+            {id = "mag_loadtime_factor", type = "track", val = 2, min=0.004,max=2,step=0.001, def = 1},
+            {id = "mag_unloadtime_factor", type = "track", val = 2, min=0.004,max=2,step=0.001, def = 1},
             {id= "mag_tooltip" ,type= "list", val= 2  ,def= 1 ,content= {{0,"topround"},  {1,"trcap"}, {2,"full"}}	},
             {id = "empty_mags_stack", type = "check", val = 1, def=true},
             {id = "sort_inv", type = "check", val = 1, def=true},
@@ -91,7 +95,8 @@ function on_mcm_load()
             {id= "hudtitle",type= "slide",text="ui_mcm_magazines_hudtitle",link= "ui_options_slider_player",size= {512,50},spacing= 20},
             {id = "show_hud", type = "check", val = 1, def=true},			
             {id = "scale", type = "track", val = 2, min=0.1,max=2,step=0.05, def = 1},
-            {id = "grp_by_bt", type = "check", val = 1, def=true},			
+            { id = "hud_offset_x", type = "track", val = 2, min = -100, max = 1200, step = 1, def = 0, text = "ui_mcm_magazines_hud_hud_offset_x", desc = "ui_mcm_magazines_hud_hud_offset_x_desc" },
+			{id = "grp_by_bt", type = "check", val = 1, def=true},			
             {id = "group_by_ammo", type = "check", val = 1, def=true},			
             {id = "icon_text", type = "check", val = 1, def=true},			
             {id = "ammo_icon", type = "check", val = 1, def=true},


### PR DESCRIPTION
i modifies mcm script and magazine hud to add a slider and change the horizontal positizion of the hud, this avoids overlappig minimap or other hud components, I also modified magazines script to allow a queue of unloading all mags with a single button, this avoid single left click uload every mags, this just works for inventory not stash. also this also works for mags NOT in loadout and NOT empty