### PR TITLE
Unload All Mags with one key (MCM) - Adjust HUD xpos slider (MCM)

### DIFF
--- a/gamedata/scripts/mag_hud.script
+++ b/gamedata/scripts/mag_hud.script
@@ -17,6 +17,7 @@ local gc						 	= game.translate_string
 local tg_update_step = 1000 --[ms]
 
 local scale = 1
+local hud_offset_x = 0
 local ammo_scale = 1
 local group_by_ammo = true
 local grp_by_bt = true
@@ -123,6 +124,9 @@ function UIMagHUD:InitControls()
 	
 	self.dialog = xml:InitStatic("pouch", self)
 	adjust_vert(self.dialog, self.bottom)
+	local pos = self.dialog:GetWndPos()
+    pos.x = hud_offset_x
+    self.dialog:SetWndPos(pos)
 	self.pouch = {}
 	self.pouch.small = xml:InitStatic("pouch:small", self.dialog)
 	adjust_vert(self.pouch.small)
@@ -361,6 +365,7 @@ end
 local function on_option_change(mcm)
 	--if not mcm then return end
 	scale = magazines_mcm.get_config("scale")
+	hud_offset_x = magazines_mcm.get_config("hud_offset_x") or 0
 	ammo_scale = magazines_mcm.get_config("ammo_scale")
 	group_by_ammo = magazines_mcm.get_config("group_by_ammo")
 	grp_by_bt = magazines_mcm.get_config("grp_by_bt")
@@ -373,6 +378,7 @@ end
 
 local function actor_on_first_update()
 	scale = magazines_mcm.get_config("scale")
+	hud_offset_x = magazines_mcm.get_config("hud_offset_x") or 0
 	ammo_scale = magazines_mcm.get_config("ammo_scale")
 	group_by_ammo = magazines_mcm.get_config("scale")
 	grp_by_bt = magazines_mcm.get_config("ammo_scale")

--- a/gamedata/scripts/magazines.script
+++ b/gamedata/scripts/magazines.script
@@ -25,7 +25,8 @@ dump_data					= magazine_binder.dump_data
 get_mags_by_ammo_type		= magazine_binder.get_mags_by_ammo_type
 get_config					= magazines_mcm.get_config
 
-
+local unload_magazine_queue = {}
+local unload_all_mags_key = DIK_keys.DIK_END  -- Default key is 'END'
 
 local dbg_log
 function print_dbg( text , ...)
@@ -145,6 +146,9 @@ end
 
 -- check if load/unload delay has been altered and wipe cache
 function on_option_change()
+	if ui_mcm then
+			unload_all_mags_key = ui_mcm.get("magazines/gameplay/unload_all_mags_key")
+		end
 	empty_table(cache_mag_time)
 end
 
@@ -862,7 +866,9 @@ function on_key_press(key, bind, dis, flags)
 			flags.ret_value = false
 		end
 	end
-	
+	if key == unload_all_mags_key then
+        	unload_all_magazines()
+    	end
 end
 
 function unload_ammo(obj)
@@ -1058,6 +1064,46 @@ function on_game_load()
 		args = str_explode(k, ",")
 		RemoveTimeEvent(args[1], args[2])
 	end
+end
+
+function unload_all_magazines()
+    unload_magazine_queue = {}
+    local actor = db.actor
+    actor:iterate_inventory(function(temp, obj)
+        if is_magazine(obj) then
+            local mag_data = get_mag_data(obj:id())
+            if mag_data and #mag_data.loaded > 0 and not is_carried_mag(obj:id()) then
+                table.insert(unload_magazine_queue, obj)
+            end
+        end
+    end)
+    if #unload_magazine_queue > 0 then
+        -- start to unload first mag
+        unload_next_magazine()
+    end
+end
+
+-- function to unload the next mag in queque
+function unload_next_magazine()
+    if #unload_magazine_queue == 0 then
+        -- all mags have been processed, quit exectuion
+        return
+    end
+
+    -- check if an action is in progress
+    if action_state ~= ACTION_NONE then
+        -- wait and retry every half sec
+        create_time_event("mag_redux", "unload_next_magazine", 0.5, unload_next_magazine)
+        return
+    end
+
+    -- get next mag from the queque
+    local obj = table.remove(unload_magazine_queue, 1)
+    if obj then
+        func_unload_ammo(obj)
+        -- wait half sec for next mag
+        create_time_event("mag_redux", "unload_next_magazine", 0.5, unload_next_magazine)
+    end
 end
 
 function on_game_start()

--- a/gamedata/scripts/magazines_mcm.script
+++ b/gamedata/scripts/magazines_mcm.script
@@ -28,6 +28,8 @@ local defaults = {
 	three_hands				= false,
     deathquality			= 1.0,
     deathammo				= 1.0,
+	unload_all_mags_key     = DIK_keys.DIK_END,
+
 }
 
 local def_map = {
@@ -58,6 +60,7 @@ local def_map = {
 	three_hands				= "gameplay",
     deathquality			= "gameplay",
     deathammo				= "gameplay",
+	unload_all_mags_key     = "gameplay",
 }
 
 local colors = {--alpha value will be reset to match slider
@@ -113,6 +116,7 @@ function on_mcm_load()
             {id = "ejection" ,type= "list" ,val= 2, def= 1, content= {{0,"loadout"},{1,"ruck"}}},
 			{ id= "rant", type= "desc", text= "ui_mcm_magazines_rant", clr= {255, 225, 0, 0}},
             {id = "three_hands", type = "check", val = 1, def=false},
+			{ id = "unload_all_mags_key", type = "key_bind", val = 2, def = DIK_keys.DIK_END },
         }},
         }
     }


### PR DESCRIPTION
addes a feature to unload all magazines in inventory with one key press customizable trough mcm, only the mags in inventory will be unloaded, not in stash. will also be unloaded only if magazines are NOT in player loadout and not empty.

added an offset to adjust the horizontal hud position to avoid overlapping the minimap or other hud elements, configurable position on mcm